### PR TITLE
#14 Made parcelle attribute name optionally configurable

### DIFF
--- a/js/extension/epics/urbanisme.js
+++ b/js/extension/epics/urbanisme.js
@@ -273,7 +273,8 @@ export const getFeatureInfoEpic = (action$, { getState }) =>
         !isEmpty(activeToolSelector(getState()))
         )
         .switchMap(({ layerMetadata }) => {
-            const parcelleId = layerMetadata.features?.[0]?.properties?.id_parc || "";
+            const {idParcelleKey} = configSelector(getState()) ?? {};
+            const parcelleId = layerMetadata.features?.[0]?.properties?.[idParcelleKey ?? "id_parc"] || "";
             const activeTool = activeToolSelector(getState());
             if (isEmpty(parcelleId)) {
                 return Rx.Observable.of(

--- a/js/extension/plugins/Extension.jsx
+++ b/js/extension/plugins/Extension.jsx
@@ -66,10 +66,12 @@ const updateEpicsName = () => {
  * @prop {string} [cfg.helpLink] help link configured for the help tool
  * @prop {string} [cfg.cadastrappUrl] cadastrapp service path url
  * @prop {string} [cfg.layer] name of the parcelle layer
+ * @prop {string} [cfg.idParcelleKey] the attribute of the feature to use as parcelle id. If missing, `id_parc` will be used.
  * @prop {string} [cfg.urbanismeappUrl] urbanisme app service path url
  * For example this will configure the help link and upon clicking on the help button in the toolbar, the link will be displayed in a new browser tab
  * ```
  * "cfg": {
+ *    "idParcelleKey": "id_parcelle",
  *    "helpUrl": "http://docs.georchestra.org/addon_urbanisme/",
  *    "cadastrappUrl": "/cadastrapp/services",
  *    "urbanismeappUrl": "/urbanisme",

--- a/js/extension/plugins/urbanisme/UrbanismeToolbar.js
+++ b/js/extension/plugins/urbanisme/UrbanismeToolbar.js
@@ -39,9 +39,9 @@ const UrbanismeToolbar = ({
 }) => {
     const { activeTool = '', showGFIPanel = false } = urbanisme;
     useEffect(() => {
-        const {cadastrappUrl, layer, urbanismeappUrl} = props;
+        const { cadastrappUrl, layer, urbanismeappUrl, idParcelleKey} = props;
         setAPIURL({cadastrappUrl, urbanismeappUrl});
-        onSetUp({layer});
+        onSetUp({ layer, idParcelleKey });
     }, [setAPIURL, onSetUp]);
 
     const { NRU, ADS, HELP } = URBANISME_TOOLS;


### PR DESCRIPTION
The issue was present only if the attribute name for the parcelle id is different from `id_parc`. Even if this is present also in the original application, this PR document that property and make the attribute name configurable.