### PR TITLE
#23: Print fix to support WMTS background layer

### DIFF
--- a/js/extension/utils/UrbanismeUtils.js
+++ b/js/extension/utils/UrbanismeUtils.js
@@ -51,9 +51,15 @@ export function getScalesForMap({projection, resolutions}, dpi) {
     return resolutions.map((resolution) => resolution * dpu);
 }
 
+/**
+ * Parse WMTS layer to support mapfish specification of Georchestra
+ * @param {object} layer
+ * @param {object} state
+ * @return {object} parsed layer
+ */
 const parseLayer = (layer, state) => {
     let parsedLayer = layer;
-    if (layer?.type.toLowerCase() === "wmts") { // Update WMTS layer to support Mapfish specification
+    if (layer?.type.toLowerCase() === "wmts") {
         const _layer = getLayerFromName(state, layer.name);
         const srs = normalizeSRS(_layer.srs || 'EPSG:3857', _layer.allowedSRS);
         const projection = getProjection(srs);


### PR DESCRIPTION
## Description
This PR adds commits to support printing with WMTS layer as background

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

##Issue

**What is the current behavior?**
#23  

**What is the new behavior?**
- WMTS layer is parsed to support mapfish v3 specification of the Georchestra
- Able to print with WMTS layer as background for both NRU & ADS

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
