### PR TITLE
#31: Avoid to rise errors when commune array is empty

### DIFF
--- a/js/extension/api.js
+++ b/js/extension/api.js
@@ -30,6 +30,9 @@ export const getCommune = cgocommune => {
     return axios
         .get(`${cadastrappURL}/getCommune`, { params: { cgocommune } })
         .then(({ data }) => {
+            if (isEmpty(data)) {
+                return null;
+            }
             const [{ libcom_min: commune }] = data;
             return { commune };
         });

--- a/js/extension/epics/__tests__/urbanisme-test.js
+++ b/js/extension/epics/__tests__/urbanisme-test.js
@@ -295,6 +295,49 @@ describe('Urbanisme EPICS', () => {
             },
             state);
     });
+    it('getFeatureInfoEpic returns even with empty data', (done) => {
+        mockAxios.onGet(`${CADASTRAPP_URL}/getCommune`).reply(200, []);
+        mockAxios.onGet(`${CADASTRAPP_URL}/getParcelle`).reply(200, []);
+        mockAxios.onGet(`${URBANISMEAPP_URL}/renseignUrba`).reply(200, {});
+        mockAxios.onGet(`${CADASTRAPP_URL}/getFIC`, ).reply((config)=>{
+            if (config.params.onglet === 0) return [200, []];
+            return [200, []];
+        });
+        mockAxios.onGet('/urbanisme/renseignUrbaInfos').reply(200, { date_pci: '2020/10/11', date_ru: '06/2020'});
+
+        const urbanismeLayer = {id: URBANISME_RASTER_LAYER_ID, name: "URBANISME_PARCELLE"};
+        const layerMetaData = {features: [{id: "urbanisme_1", geometry: {type: "Polygon", coordinates: [[-1, 1], [-2, 2], [-3, 3], [-4, 4]]}, properties: {id_parc: "350238000BM0027"}}]};
+        const state = { controls: { measure: { enabled: true}, urbanisme: { enabled: true}},
+            urbanisme: { activeTool: "NRU"},
+            layers: {flat: [urbanismeLayer]}
+        };
+        const attributes = {"datePCI": "0/10/11", "dateRU": "06/2020", libelles: []};
+        testEpic(
+            addTimeoutEpic(getFeatureInfoEpic, 60),
+            3,
+            loadFeatureInfo(1, "Response", {service: "WMS", id: URBANISME_RASTER_LAYER_ID}, layerMetaData, urbanismeLayer),
+            actions => {
+                expect(actions.length).toBe(3);
+                actions.map(action=>{
+                    switch (action.type) {
+                    case LOADING:
+                        expect(action.name).toEqual('dataLoading');
+                        expect(action.value).toBe(true);
+                        break;
+                    case TOGGLE_VIEWER_PANEL:
+                        expect(action.enabled).toBe(true);
+                        break;
+                    case SET_URBANISME_DATA:
+                        expect(action.property).toEqual(attributes);
+                        break;
+                    default:
+                        expect(true).toBe(false);
+                    }
+                });
+                done();
+            },
+            state);
+    });
 
     it('getFeatureInfoEpic load feature info', (done) => {
         mockAxios.onGet(`${URBANISMEAPP_URL}/adsSecteurInstruction`).reply(200, {nom: "nom", ini_instru: "ini"});


### PR DESCRIPTION
Avoid to rise an error when the response from "getCommune" is an empty array, I can show all the data, even when some of them are missing.
