### PR TITLE
#42 Making changes to the toggle logic of urbanisme tool

### DIFF
--- a/js/extension/actions/urbanisme.js
+++ b/js/extension/actions/urbanisme.js
@@ -35,7 +35,7 @@ export const loading = (value, name) => ({
 /**
  * Sets the activeTool for urbanisme toolbar
  * @memberof actions.toggleUrbanismeTool
- * @param {string} tool name to active
+ * @param {string|null} tool name to active
  * @return {object} with type `TOGGLE_TOOL`
  */
 export const toggleUrbanismeTool = tool => {


### PR DESCRIPTION


## Description
This PR address issues mentioned in https://github.com/sigrennesmetropole/geor_urbanisme_mapstore/issues/42#issuecomment-1047717179 and https://github.com/sigrennesmetropole/geor_urbanisme_mapstore/issues/42#issuecomment-1047795632

Made changes to the toggle logic of urbanisme tool.
It will not be closed anymore when:
- Identify tool is activated;
- Measure tool is activated;
- Map info trigger event is changed in the map settings;
Instead of it active tool will be deactivated/toggled off.
Activation of any urbanisme tool will disable identify, close measure plugin and will reset map info trigger to click.
Amended tests.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix
 - [] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
#42 

**What is the new behavior?**
As per description

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
