### PR TITLE
Urbanisme changes related to MapStore layout update

### DIFF
--- a/assets/index.json
+++ b/assets/index.json
@@ -13,7 +13,7 @@
         "layer": "urbanisme_parcelle"
       },
       "dependencies": [
-        "BurgerMenu"
+        "SidebarMenu"
       ]
     }
   ]

--- a/js/assets/style.css
+++ b/js/assets/style.css
@@ -5,7 +5,15 @@
     z-index: 1000;
     margin-bottom: 35px;
     margin-right: 5px;
-  }
+}
+
+.urbanismeToolbar.vertical {
+    width: 40px;
+}
+
+.urbanismeToolbar.vertical .btn {
+    margin: 0;
+}
 
 .table-parcelle.table {
     width: 400px;
@@ -32,7 +40,7 @@
 
 #modal-land-panel-dialog {
     position: fixed;
-    top: 0%;
+    top: 0;
     left: 20%;
     z-index: 1000 !important;
 }

--- a/js/extension/plugins/Extension.jsx
+++ b/js/extension/plugins/Extension.jsx
@@ -27,9 +27,12 @@ import {
 import { CONTROL_NAME } from "../constants";
 import "../../assets/style.css";
 import {configSelector} from "@js/extension/selectors/urbanisme";
+import {mapLayoutValuesSelector} from "@js/extension/selectors/maplayout";
 
 const Urbanisme = connect(
     state => ({
+        containerStyle: mapLayoutValuesSelector(state, { right: true, rightPanel: true }),
+        mapHeight: state?.map?.present?.size?.height,
         enabled: state?.controls?.urbanisme?.enabled || false,
         urbanisme: state?.urbanisme || {}
     }),
@@ -97,6 +100,23 @@ const UrbanismePlugin = {
             position: 1501,
             doNotHide: true,
             priority: 2
+        },
+        SidebarMenu: {
+            name: CONTROL_NAME,
+            icon: <Glyphicon glyph="th-list" />,
+            text: <Message msgId="urbanisme.title" />,
+            tooltip: "urbanisme.title",
+            action: toggleControl.bind(null, CONTROL_NAME, null),
+            selector: createSelector(
+                configSelector,
+                (configLoaded) => ({
+                    style: !!configLoaded ? {} : { display: "none" } // Hide when config failed to load
+                })
+            ),
+            position: 1501,
+            toggle: true,
+            doNotHide: true,
+            priority: 1
         }
     },
     epics: updateEpicsName(),

--- a/js/extension/plugins/urbanisme/UrbanismeToolbar.js
+++ b/js/extension/plugins/urbanisme/UrbanismeToolbar.js
@@ -17,6 +17,7 @@ import {
 } from "@js/extension/constants";
 import LandPlanning from "@js/extension/components/LandPlanningViewer";
 import {setAPIURL} from "@js/extension/api";
+import classnames from "classnames";
 
 /**
  * UrbanismeToolbar component
@@ -27,6 +28,8 @@ import {setAPIURL} from "@js/extension/api";
  * @param {func} props.onToggleTool triggered on clicking the toolbar buttons
  * @param {func} props.onToggleControl triggered on clicking the close button of the toolbar
  * @param {string} props.helpUrl configured help link from the localConfig
+ * @param {object} props.containerStyle style applied to the container element
+ * @param {number} props.mapHeight height of the map
  *
  */
 const UrbanismeToolbar = ({
@@ -36,6 +39,8 @@ const UrbanismeToolbar = ({
     onToggleTool = () => {},
     onToggleControl = () => {},
     helpUrl = HELP_LINK_DEFAULT,
+    containerStyle = {},
+    mapHeight = window.innerHeight,
     ...props
 }) => {
     const { activeTool = '', showGFIPanel = false } = urbanisme;
@@ -47,7 +52,7 @@ const UrbanismeToolbar = ({
 
     const { NRU, ADS } = URBANISME_TOOLS;
     const panelStyle = {
-        right: 5,
+        right: (containerStyle?.right ?? 0),
         zIndex: 100,
         position: "absolute",
         overflow: "auto",
@@ -58,7 +63,10 @@ const UrbanismeToolbar = ({
 
     return (
         <>
-            <div className="urbanismeToolbar" style={panelStyle}>
+            <div className={classnames({
+                "urbanismeToolbar": true,
+                "vertical": containerStyle?.rightPanel && mapHeight > 650
+            })} style={panelStyle}>
                 <Toolbar
                     btnDefaultProps={{
                         className: "square-button",
@@ -75,10 +83,9 @@ const UrbanismeToolbar = ({
                         },
                         {
                             text: <img src={ADSIcon} style={{
+                                maxWidth: '90%',
                                 width: 40,
-                                position: "relative",
-                                left: -
-                                3
+                                position: "relative"
                             }}/>,
                             tooltip: <Message msgId={'urbanisme.ads.tooltip'}/>,
                             bsStyle: activeTool === ADS ? "success" : "primary",

--- a/js/extension/selectors/maplayout.js
+++ b/js/extension/selectors/maplayout.js
@@ -1,0 +1,30 @@
+
+import {mapLayoutSelector} from "@mapstore/selectors/maplayout";
+import {memoize} from "lodash";
+
+export const boundingSidebarRectSelector = (state) => state.maplayout && state.maplayout.boundingSidebarRect || {};
+
+/**
+ * Retrieve only specific attribute from map layout
+ * @function
+ * @memberof selectors.mapLayout
+ * @param  {object} state the state
+ * @param  {object} attributes attributes to retrieve, bool {left: true}
+ * @param  {boolean} isDock flag to use dock paddings instead of toolbar paddings
+ * @return {object} selected attributes of layout of the map
+ */
+export const mapLayoutValuesSelector = memoize((state, attributes = {}, isDock = false) => {
+    const layout = mapLayoutSelector(state);
+    const boundingSidebarRect = boundingSidebarRectSelector(state);
+    return layout && Object.keys(layout).filter(key =>
+        attributes[key]).reduce((a, key) => {
+        if (isDock) {
+            return ({...a, [key]: (boundingSidebarRect[key] ?? layout[key])});
+        }
+        return ({...a, [key]: layout[key]});
+    },
+    {}) || {};
+}, (state, attributes, isDock) =>
+    JSON.stringify(mapLayoutSelector(state)) +
+    JSON.stringify(boundingSidebarRectSelector(state)) +
+    JSON.stringify(attributes) + (isDock ? '_isDock' : ''));


### PR DESCRIPTION
## Description
This PR applies several changes and improvements to the urbanisme extension to make it compatible with the updated MapStore layout (https://github.com/geosolutions-it/MapStore2/issues/8086)

1.  Urbanisme added to the sidebar menu container.
2.  Toolbar position will be changed to vertical if right panel is open & toolbar can fit to the available height (so that it won't overlap map toolbar).

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ] Other... Please describe:

<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
Urbanisme extension toolbar is always positioned horizontally, which might be a problem on small screens.

**What is the new behavior?**
Toolbar will adjust it's positioning depending on available height & right panel appearance.
Urbanisme tool will be available in sidebar menu.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
