### PR TITLE
Minor improvements to the styling

### DIFF
--- a/js/assets/style.css
+++ b/js/assets/style.css
@@ -11,8 +11,8 @@
     width: 40px;
 }
 
-.urbanismeToolbar.vertical .btn {
-    margin: 0;
+.urbanismeToolbar.vertical .btn-group .btn+.btn {
+    margin-left: 0;
 }
 
 .table-parcelle.table {

--- a/js/extension/plugins/urbanisme/UrbanismeToolbar.js
+++ b/js/extension/plugins/urbanisme/UrbanismeToolbar.js
@@ -85,7 +85,8 @@ const UrbanismeToolbar = ({
                             text: <img src={ADSIcon} style={{
                                 maxWidth: '90%',
                                 width: 40,
-                                position: "relative"
+                                position: "relative",
+                                imageRendering: '-webkit-optimize-contrast'
                             }}/>,
                             tooltip: <Message msgId={'urbanisme.ads.tooltip'}/>,
                             bsStyle: activeTool === ADS ? "success" : "primary",


### PR DESCRIPTION
This PR resolves two minor issues:
- Toolbar buttons have "margin-left: -1px" mistakenly applied when vertical layout is in use. Patched.
- Second icon of Urbanisme toolbar became blurred in Chrome due to downscaling. Applied CSS will change image-rendering CSS property that makes Chrome render downscaled image crisply.