### PR TITLE
Prevent identify dock to appear mistakenly on urbanisme toolbar closed

### DIFF
--- a/js/extension/epics/urbanisme.js
+++ b/js/extension/epics/urbanisme.js
@@ -204,7 +204,8 @@ export const toggleLandPlanningEpic = (action$, store) =>
             return !isEmpty(layer)
                 ? Rx.Observable.from([
                     removeAdditionalLayer({id: URBANISME_RASTER_LAYER_ID, owner: URBANISME_OWNER}),
-                    removeAdditionalLayer({id: URBANISME_VECTOR_LAYER_ID, owner: URBANISME_OWNER})
+                    removeAdditionalLayer({id: URBANISME_VECTOR_LAYER_ID, owner: URBANISME_OWNER}),
+                    purgeMapInfoResults()
                 ]).concat(!mapInfoEnabled ? [toggleMapInfoState()] : [])
                 : Rx.Observable.empty();
         });


### PR DESCRIPTION
This PR resolves issue introduced by https://github.com/sigrennesmetropole/geor_urbanisme_mapstore/pull/54
It also updates upstream to the latest state

Steps to reproduce:
1. Install extension from artifacts available here https://github.com/sigrennesmetropole/geor_urbanisme_mapstore/pull/54/checks
2. Add extension to the context, save it.
3. Open context and activate urbanisme toolbar. Select one of the tools and click on any plot.
4. Close urbanisme toolbar when modal with data is displayed over the map.

Expected result:
Urbanisme toolbar is closed. Identify state is toggled back to "on".

Actual behavior:
Urbanisme toolbar is closed. Identify state is toggled back to "on". Identify dock is open with the data previously available in urbanisme modal.

