### PR TITLE
Fix for the print tool of urbanisme after upstream update

### DIFF
--- a/js/extension/utils/UrbanismeUtils.js
+++ b/js/extension/utils/UrbanismeUtils.js
@@ -109,8 +109,8 @@ export const getUrbanismePrintSpec = state => {
         features: urbanismePlotFeaturesSelector(state)
     }, 'selectedPlot')];
 
-    const baseLayers = getMapfishLayersSpecification([...layersFiltered], {...spec, projection}, "map");
-    const vectorLayers = getMapfishLayersSpecification([...clickedPointFeatures], spec, "map");
+    const baseLayers = getMapfishLayersSpecification([...layersFiltered], {...spec, projection}, state, "map");
+    const vectorLayers = getMapfishLayersSpecification([...clickedPointFeatures], spec, state, "map");
     // Update layerSpec to suit Urbanisme print specification
     let layerSpec = ([...baseLayers, ...vectorLayers] || [])
         .map(


### PR DESCRIPTION
Fix urbanisme print tool. "getMapfishLayersSpecification" method signature changes to arguments had to be changed too.
Update of the upstream to the latest 2022.01.xx-geOrchestra