### PR TITLE
Livraison 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For example the plugin allows configuration of the following properties
     "layer": "urbanisme_parcelle",
     "helpUrl": "http://docs.georchestra.org/addon_urbanisme/",
   }
+* *urbanismeRenseignGroupe* - If true, this parameter enables the use of the new entry-point provided by backend project [sigrennesmetropole/addon_urbanisme](https://github.com/sigrennesmetropole/addon_urbanisme) and the generated document displayed urban informations grouped by categories (instead of a list of all urban informations). If false (default) the previous behaviour is kept.
  ```
 
 ### Running geOrchestra

--- a/assets/index.json
+++ b/assets/index.json
@@ -10,7 +10,8 @@
         "helpUrl": "http://docs.georchestra.org/addon_urbanisme/",
         "cadastrappUrl": "/cadastrapp/services",
         "urbanismeappUrl": "/urbanisme",
-        "layer": "urbanisme_parcelle"
+        "layer": "urbanisme_parcelle",
+        "urbanismeRenseignGroupe": false
       },
       "dependencies": [
         "SidebarMenu"

--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -287,7 +287,8 @@
               "helpUrl": "http://docs.georchestra.org/addon_urbanisme/",
               "cadastrappUrl": "/cadastrapp/services",
               "urbanismeappUrl": "/urbanisme",
-              "layer": "urbanisme_parcelle"
+              "layer": "urbanisme_parcelle",
+              "urbanismeRenseignGroupe": false
             }
           },
           {

--- a/js/extension/api.js
+++ b/js/extension/api.js
@@ -12,10 +12,12 @@ import {DEFAULT_CADASTRAPP_URL, DEFAULT_URBANISMEAPP_URL} from "@js/extension/co
 
 let cadastrappURL;
 let urbanismeURL;
+let renseignUrbaGroupe;
 
 export const setAPIURL = (config) => {
     cadastrappURL = config?.cadastrappUrl || DEFAULT_CADASTRAPP_URL;
     urbanismeURL = config?.urbanismeappUrl || DEFAULT_URBANISMEAPP_URL;
+    renseignUrbaGroupe = !!config?.urbanismeRenseignGroupe;
 };
 
 /* eslint-disable camelcase */
@@ -75,12 +77,29 @@ export const getParcelle = code => {
         });
 };
 
-export const getRenseignUrba = parcelle => {
+export const getRenseignUrbaNonGroupe = parcelle => {
     return axios
         .get(`${urbanismeURL}/renseignUrba`, { params: { parcelle } })
         .then(({ data }) => {
             return { libelles: (data?.libelles || []).map(({ libelle }) => libelle) };
         });
+};
+
+
+export const getRenseignUrbaGroupe = parcelle => {
+    return axios
+        .get(`${urbanismeURL}/renseignUrbaGroupe`, { params: { parcelle } })
+        .then(({ data }) => {
+            return { groupesLibelle: (data?.groupesLibelle || []), adressesPostales: (data?.adressesPostales || []) };
+        });
+};
+
+export const getRenseignUrba = parcelle => {
+    if (renseignUrbaGroupe) {
+        return getRenseignUrbaGroupe(parcelle);
+    }
+    return getRenseignUrbaNonGroupe(parcelle);
+
 };
 
 export const getFIC = (parcelle, onglet) => {

--- a/js/extension/components/LandPlanningViewer.jsx
+++ b/js/extension/components/LandPlanningViewer.jsx
@@ -52,6 +52,14 @@ const LandPlanningViewer = ({
         return null;
     };
 
+    const getLibelles = (groupesLibelle, numero) => {
+        const groupes = groupesLibelle.find(groupe => groupe?.groupe_ru === numero);
+        if (groupes) {
+            return (groupes?.libelles || []).join("<br/>");
+        }
+        return "";
+    };
+
     const onSubmitPrint = () => {
         let paramAttributes = {};
         // NRU print param attributes
@@ -69,9 +77,35 @@ const LandPlanningViewer = ({
                 adresseProprio: attributes.adresseProprio || "",
                 dateRU: attributes.dateRU || "",
                 datePCI: attributes.datePCI || "",
-                libelles: (attributes.libelles || []).join("\n\n") || [],
                 outputFilename: "NRU_" + attributes.parcelle
             };
+            if (!!attributes?.groupesLibelle) {
+                paramAttributes = {
+                    ...paramAttributes,
+                    libelles_1: getLibelles(attributes?.groupesLibelle, '1'),
+                    libelles_2: getLibelles(attributes?.groupesLibelle, '2'),
+                    libelles_311: getLibelles(attributes?.groupesLibelle, '311'),
+                    libelles_312: getLibelles(attributes?.groupesLibelle, '312'),
+                    libelles_313: getLibelles(attributes?.groupesLibelle, '313'),
+                    libelles_314: getLibelles(attributes?.groupesLibelle, '314'),
+                    libelles_315: getLibelles(attributes?.groupesLibelle, '315'),
+                    libelles_32: getLibelles(attributes?.groupesLibelle, '32'),
+                    libelles_33: getLibelles(attributes?.groupesLibelle, '33'),
+                    libelles_4: getLibelles(attributes?.groupesLibelle, '4'),
+                    libelles_5: getLibelles(attributes?.groupesLibelle, '5'),
+                    libelles_6: getLibelles(attributes?.groupesLibelle, '6'),
+                    libelles_7: getLibelles(attributes?.groupesLibelle, '7'),
+                    libelles_alertes: getLibelles(attributes?.groupesLibelle, '-999'),
+                    adressesPostales: attributes.adressesPostales.join("; "),
+                    intra: true,
+                    mapImageStream: null
+                };
+            } else {
+                paramAttributes = {
+                    ...paramAttributes,
+                    libelles: (attributes.libelles || []).join("\n\n") || []
+                };
+            }
         } else if (activeTool === ADS) {
             // ADS print param attributes
             const { emptyNom, emptyNumNom } = ADS_DEFAULTS;

--- a/js/extension/components/NRUInfo.jsx
+++ b/js/extension/components/NRUInfo.jsx
@@ -82,9 +82,14 @@ const NRUInfo = (props) => {
                 </tbody>
             </Table>
             <div>
-                {(props.libelles || []).map(libelle => (
-                    <p className="libelle" dangerouslySetInnerHTML={{ __html: libelle }}></p>
-                ))}
+                {(!!props?.groupesLibelle) ?
+                    (props.groupesLibelle || []).map(groupe => (
+                        (groupe.libelles || []).map(libelle => (
+                            <p className="libelle" dangerouslySetInnerHTML={{ __html: libelle }}></p>))
+                    )) :
+                    (props.libelles || []).map(libelle => (
+                        <p className="libelle" dangerouslySetInnerHTML={{ __html: libelle }}></p>
+                    ))}
             </div>
         </div>
     );

--- a/js/extension/epics/urbanisme.js
+++ b/js/extension/epics/urbanisme.js
@@ -413,12 +413,12 @@ export const getFeatureInfoEpic = (action$, {getState}) =>
                     getFIC(parcelleId, 1),
                     getRenseignUrbaInfos(codeCommune)
                 ).switchMap(
-                    ([commune, parcelle, lisbelle, propPrio, proprioSurf, dates]) => {
+                    ([commune, parcelle, renseignUrba, propPrio, proprioSurf, dates]) => {
                         return Rx.Observable.of(
                             setAttributes({
                                 ...commune,
                                 ...parcelle,
-                                ...lisbelle,
+                                ...renseignUrba,
                                 ...propPrio,
                                 ...proprioSurf,
                                 ...dates

--- a/js/extension/plugins/Extension.jsx
+++ b/js/extension/plugins/Extension.jsx
@@ -71,6 +71,7 @@ const updateEpicsName = () => {
  * @prop {string} [cfg.layer] name of the parcelle layer
  * @prop {string} [cfg.idParcelleKey] the attribute of the feature to use as parcelle id. If missing, `id_parc` will be used.
  * @prop {string} [cfg.urbanismeappUrl] urbanisme app service path url
+ * @prop {boolean} [cfg.urbanismeRenseignGroupe] True if getRenseignUrba should return grouped libelles
  * For example this will configure the help link and upon clicking on the help button in the toolbar, the link will be displayed in a new browser tab
  * ```
  * "cfg": {
@@ -78,6 +79,7 @@ const updateEpicsName = () => {
  *    "helpUrl": "http://docs.georchestra.org/addon_urbanisme/",
  *    "cadastrappUrl": "/cadastrapp/services",
  *    "urbanismeappUrl": "/urbanisme",
+ *    "urbanismeRenseignGroupe": false
  *    "layer": "urbanisme_parcelle"
  *  }
  * ```

--- a/js/extension/plugins/urbanisme/UrbanismeToolbar.js
+++ b/js/extension/plugins/urbanisme/UrbanismeToolbar.js
@@ -44,8 +44,8 @@ const UrbanismeToolbar = ({
 }) => {
     const { activeTool = '', showGFIPanel = false } = urbanisme;
     useEffect(() => {
-        const { cadastrappUrl, layer, urbanismeappUrl, idParcelleKey} = props;
-        onSetUp({ layer, idParcelleKey, cadastrappUrl, urbanismeappUrl });
+        const { cadastrappUrl, layer, urbanismeappUrl, idParcelleKey, urbanismeRenseignGroupe} = props;
+        onSetUp({ layer, idParcelleKey, cadastrappUrl, urbanismeappUrl, urbanismeRenseignGroupe });
     }, [onSetUp]);
 
     const { NRU, ADS } = URBANISME_TOOLS;

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "vusion-webfonts-generator": "0.4.1",
         "webpack": "5.9.0",
         "webpack-bundle-size-analyzer": "2.0.2",
-        "webpack-cli": "^4.9.0",
+        "webpack-cli": "4.10.0",
         "webpack-dev-server": "3.11.0",
         "zip-webpack-plugin": "^3.0.0"
     },


### PR DESCRIPTION
This pull request embeds 2 main proposals :
- The migration to mapstore 2022.02.XX.
- The new parameter "renseignUrbaGroupe" and a new jasper template.

The jasper template has been modified to provide generation of urban information grouped by theme.
The "urbanismeRenseignGroupe" parameter is used to configure the use of this grouping (default value is false).

If the "urbanismeRenseignGroupe" parameter is set to true, the new API from sigrennesmetropole/addon_urbanisme is used and the document of urban information is generated grouped by theme.
If the "urbanismeRenseignGroupe" parameter is set to false, the legacy API from sigrennesmetropole/addon_urbanisme is used and the document of urban information as before.